### PR TITLE
Fix running debug session before switching to rootfs and make it halt boot

### DIFF
--- a/init-script
+++ b/init-script
@@ -327,7 +327,7 @@ if [ "$DONE_SWITCH" = "no" ]; then
 	if [ -f $lun ]; then echo /dev/mmcblk0 > $lun; fi
 	USB_FUNCTIONS=rndis,mass_storage
 
-	run_debug_session $DBG_REASON
+	run_debug_session "$DBG_REASON" "y"
 
 	# Tidy up before we switch_root (rootfs init-debug leaves these running during bootup)
 	killall telnetd


### PR DESCRIPTION
There is a bug in hybris-boot init-script preventing any debug condition, such as /init_enter_debug, from actually suspending boot process before switching to rootfs.

Wrap $DBG_REASON with quote marks since it can contain spaces and set second argument (HALT_BOOT) to "y" to make it suspend boot process.