### PR TITLE
Add support for read-only rootfs

### DIFF
--- a/init-script
+++ b/init-script
@@ -337,15 +337,22 @@ if [ "$DONE_SWITCH" = "no" ]; then
 	usb_setup "Mer Debug: done debug, disabling storage"
     fi
 
+    # Remount the target as ro if it provides the .halium-ro file
+    if [ -e /target/.halium-ro ]; then
+        mount /target -o remount,ro
+    fi
+
     # Disable mdev hotplug now - let udev handle it in main boot
     echo "" > /proc/sys/kernel/hotplug
 
     if [ -f "/target/init-debug" ]; then
-        exec switch_root /target /init-debug &> /target/init-debug-stderrout
+        echo "hybris-boot: Running init-debug" > /target/data/init-debug-stderrout
+        exec switch_root /target /init-debug >> /target/data/init-debug-stderrout 2>&1
     else
         # Prefer /sbin/preinit over /sbin/init
         [ -x /target/sbin/preinit ] && INIT=/sbin/preinit || INIT=/sbin/init
-        exec switch_root /target $INIT &> /target/init-stderrout
+        echo "hybris-boot: Booting $INIT in real rootfs" > /target/data/init-stderrout
+        exec switch_root /target $INIT >> /target/data/init-stderrout 2>&1
     fi
     run_debug_session "Failed to boot init in real rootfs"
 


### PR DESCRIPTION
Now a rootfs can provide the `/.halium-ro` file if it would rather be mounted read-only. The remount takes place before any init is run.

To account for this, I've changed the logs to redirect directly to the data partition. 

I've also changed the switch_root redirection slightly so that we can get a small confirmation that a handoff occurred correctly between hybris-boot and the init. This was particularly useful for me as I made a mistake causing `init` to be run instead of `preinit`. 