### PR TITLE
Add e2fsck to the initrd and use it when mounting stowaways

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -73,6 +73,7 @@ endif
 
 # Command used to make the image
 BB_STATIC := $(PRODUCT_OUT)/utilities/busybox
+E2FSCK_STATIC := $(PRODUCT_OUT)/utilities/e2fsck
 
 ifneq ($(strip $(TARGET_NO_KERNEL)),true)
   INSTALLED_KERNEL_TARGET := $(PRODUCT_OUT)/kernel
@@ -142,7 +143,7 @@ else
 	@mkbootimg --ramdisk $(BOOT_RAMDISK) $(HYBRIS_BOOTIMAGE_ARGS) $(BOARD_MKBOOTIMG_ARGS) --output $@
 endif
 
-$(BOOT_RAMDISK): $(BOOT_RAMDISK_FILES) $(BB_STATIC)
+$(BOOT_RAMDISK): $(BOOT_RAMDISK_FILES) $(BB_STATIC) $(E2FSCK_STATIC)
 	@echo "Making initramfs : $@"
 	@rm -rf $(BOOT_INTERMEDIATE)/initramfs
 	@mkdir -p $(BOOT_INTERMEDIATE)/initramfs
@@ -151,6 +152,7 @@ $(BOOT_RAMDISK): $(BOOT_RAMDISK_FILES) $(BB_STATIC)
 # really hard to depend on things which may affect init.
 	@mv $(BOOT_RAMDISK_INIT) $(BOOT_INTERMEDIATE)/initramfs/init
 	@cp $(BB_STATIC) $(BOOT_INTERMEDIATE)/initramfs/bin/
+	@cp $(E2FSCK_STATIC) $(RECOVERY_INTERMEDIATE)/initramfs/bin/
 ifeq ($(BOARD_CUSTOM_MKBOOTIMG),pack_intel)
 	@(cd $(BOOT_INTERMEDIATE)/initramfs && find . | cpio -H newc -o ) | $(MINIGZIP) > $(BOOT_RAMDISK)
 else
@@ -193,13 +195,14 @@ else
 	$(hide)$(MKBOOTIMG) --ramdisk $(RECOVERY_RAMDISK) $(HYBRIS_RECOVERYIMAGE_ARGS) $(BOARD_MKRECOVERYIMG_ARGS) --output $@
 endif
 
-$(RECOVERY_RAMDISK): $(RECOVERY_RAMDISK_FILES) $(BB_STATIC)
+$(RECOVERY_RAMDISK): $(RECOVERY_RAMDISK_FILES) $(BB_STATIC) $(E2FSCK_STATIC)
 	@echo "Making initramfs : $@"
 	@rm -rf $(RECOVERY_INTERMEDIATE)/initramfs
 	@mkdir -p $(RECOVERY_INTERMEDIATE)/initramfs
 	@cp -a $(RECOVERY_RAMDISK_SRC)/*  $(RECOVERY_INTERMEDIATE)/initramfs
 	@mv $(RECOVERY_RAMDISK_INIT) $(RECOVERY_INTERMEDIATE)/initramfs/init
 	@cp $(BB_STATIC) $(RECOVERY_INTERMEDIATE)/initramfs/bin/
+	@cp $(E2FSCK_STATIC) $(RECOVERY_INTERMEDIATE)/initramfs/bin/
 ifeq ($(BOARD_CUSTOM_MKBOOTIMG),pack_intel)
 	@(cd $(RECOVERY_INTERMEDIATE)/initramfs && find . | cpio -H newc -o ) | $(MINIGZIP) > $(RECOVERY_RAMDISK)
 else

--- a/Android.mk
+++ b/Android.mk
@@ -152,7 +152,7 @@ $(BOOT_RAMDISK): $(BOOT_RAMDISK_FILES) $(BB_STATIC) $(E2FSCK_STATIC)
 # really hard to depend on things which may affect init.
 	@mv $(BOOT_RAMDISK_INIT) $(BOOT_INTERMEDIATE)/initramfs/init
 	@cp $(BB_STATIC) $(BOOT_INTERMEDIATE)/initramfs/bin/
-	@cp $(E2FSCK_STATIC) $(RECOVERY_INTERMEDIATE)/initramfs/bin/
+	@cp $(E2FSCK_STATIC) $(BOOT_INTERMEDIATE)/initramfs/bin/
 ifeq ($(BOARD_CUSTOM_MKBOOTIMG),pack_intel)
 	@(cd $(BOOT_INTERMEDIATE)/initramfs && find . | cpio -H newc -o ) | $(MINIGZIP) > $(BOOT_RAMDISK)
 else

--- a/init-script
+++ b/init-script
@@ -137,22 +137,42 @@ bootsplash() {
 
 
 mount_stowaways() {
-    echo "########################## mounting stowaways"
-    if [ ! -z $DATA_PARTITION ]; then
-        data_subdir="$(get_opt data_subdir)"
+	echo "########################## mounting stowaways"
+	if [ ! -z $DATA_PARTITION ]; then
+		data_subdir="$(get_opt data_subdir)"
 
 	mkdir /data
 	mkdir /target
 
-	mount $DATA_PARTITION /data
+	echo "Checking filesystem integrity for the userdata partition"
+	fsck_start=`date +%s`
+	
+	# Mounting and unmounting /data means the kernel will handle the 
+	# journal/orphans, this is faster than e2fsck doing everything
+	mkdir /tmpmnt
+	mount $DATA_PARTITION /tmpmnt -o errors=remount-ro
+	umount /tmpmnt
+	rmdir /tmpmnt
+	e2fsck -y $DATA_PARTITION
+
+	fsck_end=`date +%s`
+	echo "Finished checking, took $((fsck_end-fsck_start)) second(s)"
+	mount -o discard,data=journal $DATA_PARTITION /data
+
+	echo "Checking rootfs filesystem integrity"
+	fsck_start=`date +%s`
+	e2fsck -y /data/rootfs.img
+	fsck_end=`date +%s`
+	echo "Finished checking, took $((fsck_end-fsck_start)) second(s)"
+
 	mount /data/rootfs.img /target
 
 	mkdir -p /target/data # in new fs
 	mount --bind /data/${data_subdir} /target/data
-    else
-        echo "Failed to mount /target, device node '$DATA_PARTITION' not found!" >> /diagnosis.log
-    fi
-    mount
+	else
+		echo "Failed to mount /target, device node '$DATA_PARTITION' not found!" >> /diagnosis.log
+	fi
+	mount
 }
 
 umount_stowaways() {


### PR DESCRIPTION
This builds a statically linked e2fsck binary and adds it to `/bin`. `mount_stowaways` is changed to mount, then unmount, then fsck `/data` before using it for anything important. The mount of `/data` is performed with `data=journal`. This will cause a performance hit, but should also mean less file corruption in the long run.

Side note, the mount-unmount-fsck pattern causes the kernel to replay the ext4 journal rather than e2fsck. Canonical engineers stated that the kernel was faster at this task.

**Pros:**

* This is almost exactly how Canonical solved issues with file corruption breaking AppArmor profiles on Ubuntu Phone devices in the very early days of the project: [launchpad #1387214](https://bugs.launchpad.net/ubuntu-rtm/+source/android-tools/+bug/1387214)

* Only adds a small amount of time to the boot process, normally one second or less. 

**Cons:**

* This will cause the RW reference and Plasma Mobile rootfs's to be deleted slightly more often as fsck will realize that something is wrong with them. I experienced this while testing. I feel that this is better than allowing silent corruption to the image, but the result is undesirable.

* The boot.img is now > 8MB on my device, sitting at 9.2MB. This shouldn't be a concern except for very old devices with ridiculously small boot partitions.

**To test this:**

Just pull the branch for this PR and build hybris-boot or hybris-recovery. Flash them to the device's `boot` partition. You'll find the fsck output after `[...]## mounting stowaways` in the logs. Boot the device.