### PR TITLE
Improve logging

### DIFF
--- a/init-script
+++ b/init-script
@@ -146,7 +146,7 @@ get_opt() {
 # Minimal mounts for initrd or pre-init debug session
 do_mount_devprocsys()
 {
-    echo "########################## mounting devprocsys"
+    echo "mounting devprocsys"
     mkdir /dev
     mount -t devtmpfs devtmpfs /dev
     # telnetd needs /dev/pts/ entries
@@ -175,7 +175,7 @@ bootsplash() {
 
 
 mount_stowaways() {
-    log "########################## mounting stowaways DATA_PARTITION=\"$DATA_PARTITION\", data_subdir=\"$data_subdir\""
+    log "mounting stowaways DATA_PARTITION=\"$DATA_PARTITION\", data_subdir=\"$data_subdir\""
     if [ ! -z $DATA_PARTITION ]; then
         data_subdir="$(get_opt data_subdir)"
 
@@ -228,7 +228,7 @@ inject_loop() {
     mkfifo $INJ_STDIN
     echo "This entire directory is for debugging init - it can safely be removed" > $INJ_DIR/README
 
-    log "########################## Beginning inject loop"
+    log "Beginning inject loop"
     while : ; do
         while read IN; do
 	    if [ "$IN" = "continue" ]; then break 2;fi
@@ -236,7 +236,7 @@ inject_loop() {
         done <$INJ_STDIN
     done
     rm -rf $INJ_DIR # Clean up if we exited nicely
-    log "########################## inject loop done"
+    log "inject loop done"
 }
 
 # This sets up the USB with whatever USB_FUNCTIONS are set to
@@ -259,7 +259,7 @@ usb_setup() {
 run_debug_session() {
     breathe
     CUSTOMPRODUCT=$1
-    log "########################## Debug session : $1"
+    log "Debug session : $1"
     log "DONE_SWITCH=$DONE_SWITCH"
 
     USB_IFACE=notfound
@@ -286,7 +286,7 @@ run_debug_session() {
     echo "option subnet 255.255.255.0" >> /etc/udhcpd.conf
 
     # Be explicit about busybox so this works in a rootfs too
-    log "########################## starting dhcpd"
+    log "starting dhcpd"
     $EXPLICIT_BUSYBOX udhcpd
 
     HALT_BOOT="${2:-y}"
@@ -294,7 +294,7 @@ run_debug_session() {
 
     if [ -z $DISABLE_TELNET ]; then
     # Non-blocking telnetd
-    log "########################## starting telnetd"
+    log "starting telnetd"
     # We run telnetd on different ports pre/post-switch_root This
     # avoids problems with an unterminated pre-switch_root telnetd
     # hogging the port

--- a/init-script
+++ b/init-script
@@ -30,20 +30,6 @@ DATA_PARTITION=%DATA_PART%
 DEFAULT_OS=%DEFAULT_OS%
 DEBUG_REASON=
 
-export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin
-
-# Default setting is rndis - add mass_storage for a debug boot
-# enable using usb_setup
-USB_FUNCTIONS=rndis
-
-ANDROID_USB=/sys/class/android_usb/android0
-LOCAL_IP=192.168.2.15
-
-DONE_SWITCH=no
-# Are we running in real rootfs
-if [ "$0" = "/init-debug" ]; then
-    DONE_SWITCH=yes
-fi
 
 log(){
 
@@ -135,14 +121,27 @@ EOF
 fi
 }
 
+export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin
+
+# Default setting is rndis - add mass_storage for a debug boot
+# enable using usb_setup
+USB_FUNCTIONS=rndis
+
+ANDROID_USB=/sys/class/android_usb/android0
+LOCAL_IP=192.168.2.15
+
+DONE_SWITCH=no
+# Are we running in real rootfs
+if [ "$0" = "/init-debug" ]; then
+    DONE_SWITCH=yes
+fi
 
 # Get options from kernel command line
 get_opt() {
-    for param in $(cat /proc/cmdline); do
-        echo "$param" | grep "^$1=*" | cut -d'=' -f2
-    done
+  for param in $(cat /proc/cmdline); do
+    echo "$param" | grep "^$1=*" | cut -d'=' -f2
+  done
 }
-
 
 # Minimal mounts for initrd or pre-init debug session
 do_mount_devprocsys()
@@ -160,7 +159,6 @@ do_mount_devprocsys()
     mount -t proc proc /proc
 }
 
-
 do_hotplug_scan()
 {
     echo /sbin/mdev > /proc/sys/kernel/hotplug
@@ -169,10 +167,9 @@ do_hotplug_scan()
     sleep 2
 }
 
-
 bootsplash() {
     if [ x$BOOTLOGO = x1 ]; then
-        zcat /bootsplash.gz > /dev/fb0
+	zcat /bootsplash.gz > /dev/fb0
     fi
 }
 
@@ -210,15 +207,18 @@ mount_stowaways() {
     mount
 }
 
-
 umount_stowaways() {
     if [ ! -z $DATA_PARTITION ]; then
-        umount /target/data
-        umount /target
-        umount /data
+	umount /target/data
+	umount /target
+	umount /data
     fi
 }
 
+# Sugar for accessing usb config
+write() {
+  echo -n "$2" > "$1"
+}
 
 inject_loop() {
     INJ_DIR=/init-ctl
@@ -231,7 +231,7 @@ inject_loop() {
     log "########################## Beginning inject loop"
     while : ; do
         while read IN; do
-            if [ "$IN" = "continue" ]; then break 2;fi
+	    if [ "$IN" = "continue" ]; then break 2;fi
             $IN
         done <$INJ_STDIN
     done
@@ -239,26 +239,20 @@ inject_loop() {
     log "########################## inject loop done"
 }
 
-
-# Sugar for accessing usb config
-write() {
-    echo -n "$2" > "$1"
-}
-
 # This sets up the USB with whatever USB_FUNCTIONS are set to
 usb_setup() {
-    write $ANDROID_USB/enable        0
-    write $ANDROID_USB/functions     ""
-    write $ANDROID_USB/enable        1
-    usleep 500000 # 0.5 delay to attempt to remove rndis function
-    write $ANDROID_USB/enable        0
-    write $ANDROID_USB/idVendor      18D1
-    write $ANDROID_USB/idProduct     D001
-    write $ANDROID_USB/iManufacturer "Mer Boat Loader"
-    write $ANDROID_USB/iProduct      "$CUSTOMPRODUCT"
-    write $ANDROID_USB/iSerial       "$1"
-    write $ANDROID_USB/functions     $USB_FUNCTIONS
-    write $ANDROID_USB/enable        1
+      write $ANDROID_USB/enable        0
+      write $ANDROID_USB/functions     ""
+      write $ANDROID_USB/enable        1
+      usleep 500000 # 0.5 delay to attempt to remove rndis function
+      write $ANDROID_USB/enable        0
+      write $ANDROID_USB/idVendor      18D1
+      write $ANDROID_USB/idProduct     D001
+      write $ANDROID_USB/iManufacturer "Mer Boat Loader"
+      write $ANDROID_USB/iProduct      "$CUSTOMPRODUCT"
+      write $ANDROID_USB/iSerial       "$1"
+      write $ANDROID_USB/functions     $USB_FUNCTIONS
+      write $ANDROID_USB/enable        1
 }
 
 
@@ -278,10 +272,10 @@ run_debug_session() {
 
     # Unable to set up USB interface? Reboot.
     if [ x$USB_IFACE = xnotfound ]; then
-        log "Mer Debug: ERROR: could not setup USB as usb0 or rndis0"
-        dmesg
-        sleep 60 # plenty long enough to check usb on host
-        reboot -f
+	    log "Mer Debug: ERROR: could not setup USB as usb0 or rndis0"
+	    dmesg
+	    sleep 60 # plenty long enough to check usb on host
+	    reboot -f
     fi
 
     # Create /etc/udhcpd.conf file.
@@ -299,15 +293,15 @@ run_debug_session() {
     set_welcome_msg $HALT_BOOT
 
     if [ -z $DISABLE_TELNET ]; then
-        # Non-blocking telnetd
-        log "########################## starting telnetd"
-        # We run telnetd on different ports pre/post-switch_root This
-        # avoids problems with an unterminated pre-switch_root telnetd
-        # hogging the port
-        $EXPLICIT_BUSYBOX telnetd -b ${LOCAL_IP}:${TELNET_DEBUG_PORT} -l /bin/sh
+    # Non-blocking telnetd
+    log "########################## starting telnetd"
+    # We run telnetd on different ports pre/post-switch_root This
+    # avoids problems with an unterminated pre-switch_root telnetd
+    # hogging the port
+    $EXPLICIT_BUSYBOX telnetd -b ${LOCAL_IP}:${TELNET_DEBUG_PORT} -l /bin/sh
 
-        # For some reason this does not work in rootfs
-        log "Mer Debug telnet on port $TELNET_DEBUG_PORT on $USB_IFACE $LOCAL_IP - also running udhcpd"
+    # For some reason this does not work in rootfs
+    log "Mer Debug telnet on port $TELNET_DEBUG_PORT on $USB_IFACE $LOCAL_IP - also running udhcpd"
     fi
 
     if [ "$HALT_BOOT" = "y" ]; then
@@ -323,32 +317,25 @@ run_debug_session() {
     fi
 }
 
-
 # writes to /diagnosis.log if there's a problem
 check_kernel_config() {
     log "Checking kernel config"
     if [ ! -e /proc/config.gz ]; then
         log "No /proc/config.gz. Enable CONFIG_IKCONFIG and CONFIG_IKCONFIG_PROC" | tee -a /diagnosis.log
     else
-        # Must be =y
-        for x in CONFIG_CGROUPS CONFIG_AUTOFS4_FS CONFIG_DEVTMPFS_MOUNT CONFIG_DEVTMPFS CONFIG_UNIX CONFIG_INOTIFY_USER CONFIG_SYSVIPC CONFIG_NET CONFIG_PROC_FS CONFIG_SIGNALFD CONFIG_SYSFS CONFIG_TMPFS_POSIX_ACL CONFIG_VT; do
-            zcat /proc/config.gz | grep -E "^$x=y\$" || echo "$x=y not found in /proc/config.gz" >> /diagnosis.log
-        done
-        # Must not be =y
-        for x in CONFIG_ANDROID_LOW_MEMORY_KILLER CONFIG_DUMMY CONFIG_SYSFS_DEPRECATED; do
-            zcat /proc/config.gz | grep -E "^$x=y\$" && echo "$x=y found in /proc/config.gz, must be disabled" >> /diagnosis.log
-        done
+	# Must be =y
+	for x in CONFIG_CGROUPS CONFIG_AUTOFS4_FS CONFIG_DEVTMPFS_MOUNT CONFIG_DEVTMPFS CONFIG_UNIX CONFIG_INOTIFY_USER CONFIG_SYSVIPC CONFIG_NET CONFIG_PROC_FS CONFIG_SIGNALFD CONFIG_SYSFS CONFIG_TMPFS_POSIX_ACL CONFIG_VT; do
+		zcat /proc/config.gz | grep -E "^$x=y\$" || echo "$x=y not found in /proc/config.gz" >> /diagnosis.log
+ 	done
+	# Must not be =y
+	for x in CONFIG_ANDROID_LOW_MEMORY_KILLER CONFIG_DUMMY CONFIG_SYSFS_DEPRECATED; do
+		zcat /proc/config.gz | grep -E "^$x=y\$" && echo "$x=y found in /proc/config.gz, must be disabled" >> /diagnosis.log
+	done
     fi
 }
 
-
-
-
-
-
-
-#############################################################
 # Now either initrd or rootfs sequence
+
 if [ "$DONE_SWITCH" = "no" ]; then
     EXPLICIT_BUSYBOX=""
     TELNET_DEBUG_PORT=23
@@ -385,23 +372,23 @@ if [ "$DONE_SWITCH" = "no" ]; then
     [ "$COUNT_VOLUP" -ge 3 ] && DBG_REASON="Repeated VOLUMEUP"
 
     log "DBG_REASON=$DBG_REASON"
+
     if ! [ "$DBG_REASON" = "" ] ; then
-        # During debug we export mmc too (some variations in location here)
-        lun=/sys/class/android_usb/f_mass_storage/lun/file
-        if [ -f $lun ]; then echo /dev/mmcblk0 > $lun; fi
+	# During debug we export mmc too (some variations in location here)
+	lun=/sys/class/android_usb/f_mass_storage/lun/file
+	if [ -f $lun ]; then echo /dev/mmcblk0 > $lun; fi
+	lun=/sys/class/android_usb/f_mass_storage/lun0/file
+	if [ -f $lun ]; then echo /dev/mmcblk0 > $lun; fi
+	USB_FUNCTIONS=rndis,mass_storage
 
-        lun=/sys/class/android_usb/f_mass_storage/lun0/file
-        if [ -f $lun ]; then echo /dev/mmcblk0 > $lun; fi
+	run_debug_session "$DBG_REASON" "y"
 
-        USB_FUNCTIONS=rndis,mass_storage
-        run_debug_session "$DBG_REASON" "y"
+	# Tidy up before we switch_root (rootfs init-debug leaves these running during bootup)
+	killall telnetd
+	killall udhcpd
 
-        # Tidy up before we switch_root (rootfs init-debug leaves these running during bootup)
-        killall telnetd
-        killall udhcpd
-
-        USB_FUNCTIONS=rndis
-        log "Mer Debug: done debug, disabling storage"
+	USB_FUNCTIONS=rndis
+	log "Mer Debug: done debug, disabling storage"
     fi
 
     # Remount the target as ro if it provides the .halium-ro file

--- a/init-script
+++ b/init-script
@@ -28,6 +28,58 @@ BOOTLOGO=%BOOTLOGO%
 ALWAYSDEBUG=%ALWAYSDEBUG%
 DATA_PARTITION=%DATA_PART%
 DEFAULT_OS=%DEFAULT_OS%
+DEBUG_REASON=
+
+export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin
+
+# Default setting is rndis - add mass_storage for a debug boot
+# enable using usb_setup
+USB_FUNCTIONS=rndis
+
+ANDROID_USB=/sys/class/android_usb/android0
+LOCAL_IP=192.168.2.15
+
+DONE_SWITCH=no
+# Are we running in real rootfs
+if [ "$0" = "/init-debug" ]; then
+    DONE_SWITCH=yes
+fi
+
+log(){
+
+    # log to std out
+    echo "$*"
+
+    # log to usb serial number
+    # this only works after usb_setup()
+    [ -w $ANDROID_USB/iSerial ] && echo -n "$*" > $ANDROID_USB/iSerial ; sleep 1
+
+    # log to kernel log
+    # this only works after do_mount_devprocsys()
+    [ -w /dev/kmsg ] && echo "init-script: $*" >> /dev/kmsg
+}
+
+blink() {
+    for i in $(seq 1 1 $1 ) ; do
+        echo 200 > /sys/class/leds/white/brightness
+        sleep 0.2
+        echo 0 > /sys/class/leds/white/brightness
+        sleep 0.2
+    done
+    sleep 1
+}
+
+
+breathe() {
+    for i in $(seq 0 20 100) ; do
+        echo $i > /sys/class/leds/white/brightness ;
+        sleep 0.1 ;
+    done
+    for i in $(seq 100 -20 0) ; do
+        echo $i > /sys/class/leds/white/brightness ;
+        sleep 0.1 ;
+    done
+}
 
 set_welcome_msg(){
 cat <<EOF > /etc/issue.net
@@ -83,27 +135,14 @@ EOF
 fi
 }
 
-export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin
-
-# Default setting is rndis - add mass_storage for a debug boot
-# enable using usb_setup
-USB_FUNCTIONS=rndis
-
-ANDROID_USB=/sys/class/android_usb/android0
-LOCAL_IP=192.168.2.15
-
-DONE_SWITCH=no
-# Are we running in real rootfs
-if [ "$0" = "/init-debug" ]; then
-    DONE_SWITCH=yes
-fi
 
 # Get options from kernel command line
 get_opt() {
-  for param in $(cat /proc/cmdline); do
-    echo "$param" | grep "^$1=*" | cut -d'=' -f2
-  done
+    for param in $(cat /proc/cmdline); do
+        echo "$param" | grep "^$1=*" | cut -d'=' -f2
+    done
 }
+
 
 # Minimal mounts for initrd or pre-init debug session
 do_mount_devprocsys()
@@ -121,6 +160,7 @@ do_mount_devprocsys()
     mount -t proc proc /proc
 }
 
+
 do_hotplug_scan()
 {
     echo /sbin/mdev > /proc/sys/kernel/hotplug
@@ -129,44 +169,56 @@ do_hotplug_scan()
     sleep 2
 }
 
+
 bootsplash() {
     if [ x$BOOTLOGO = x1 ]; then
-	zcat /bootsplash.gz > /dev/fb0
+        zcat /bootsplash.gz > /dev/fb0
     fi
 }
 
 
 mount_stowaways() {
-    echo "########################## mounting stowaways"
+    log "########################## mounting stowaways DATA_PARTITION=\"$DATA_PARTITION\", data_subdir=\"$data_subdir\""
     if [ ! -z $DATA_PARTITION ]; then
         data_subdir="$(get_opt data_subdir)"
 
-	mkdir /data
-	mkdir /target
+        mkdir /data
+        mount $DATA_PARTITION /data
+        retval=$?
+        if [ $retval -ne 0 ] ; then
+            blink 5
+            log "Failed to mount /data [$retval]" >> /diagnosis.log
+            DEBUG_REASON="/data not mounted"
+            return
+        fi
 
-	mount $DATA_PARTITION /data
-	mount /data/rootfs.img /target
+        mkdir /target
+        mount /data/rootfs.img /target
+        retval=$?
+        if [ $retval -ne 0 ] ; then
+            blink 6
+            log "Failed to mount /target [$retval]" >> /diagnosis.log
+            DEBUG_REASON="/target not mounted"
+            return
+        fi
 
-	mkdir -p /target/data # in new fs
-	mount --bind /data/${data_subdir} /target/data
+        mkdir -p /target/data # in new fs
+        mount --bind /data/${data_subdir} /target/data
     else
-        echo "Failed to mount /target, device node '$DATA_PARTITION' not found!" >> /diagnosis.log
+        log "Failed to mount /target, device node '$DATA_PARTITION' not found!" >> /diagnosis.log
     fi
     mount
 }
 
+
 umount_stowaways() {
     if [ ! -z $DATA_PARTITION ]; then
-	umount /target/data
-	umount /target
-	umount /data
+        umount /target/data
+        umount /target
+        umount /data
     fi
 }
 
-# Sugar for accessing usb config
-write() {
-  echo -n "$2" > "$1"
-}
 
 inject_loop() {
     INJ_DIR=/init-ctl
@@ -176,45 +228,45 @@ inject_loop() {
     mkfifo $INJ_STDIN
     echo "This entire directory is for debugging init - it can safely be removed" > $INJ_DIR/README
 
-    echo "########################## Beginning inject loop"
+    log "########################## Beginning inject loop"
     while : ; do
         while read IN; do
-	    if [ "$IN" = "continue" ]; then break 2;fi
+            if [ "$IN" = "continue" ]; then break 2;fi
             $IN
         done <$INJ_STDIN
     done
     rm -rf $INJ_DIR # Clean up if we exited nicely
-    echo "########################## inject loop done"
+    log "########################## inject loop done"
+}
+
+
+# Sugar for accessing usb config
+write() {
+    echo -n "$2" > "$1"
 }
 
 # This sets up the USB with whatever USB_FUNCTIONS are set to
 usb_setup() {
-      write $ANDROID_USB/enable        0
-      write $ANDROID_USB/functions     ""
-      write $ANDROID_USB/enable        1
-      usleep 500000 # 0.5 delay to attempt to remove rndis function
-      write $ANDROID_USB/enable        0
-      write $ANDROID_USB/idVendor      18D1
-      write $ANDROID_USB/idProduct     D001
-      write $ANDROID_USB/iManufacturer "Mer Boat Loader"
-      write $ANDROID_USB/iProduct      "$CUSTOMPRODUCT"
-      write $ANDROID_USB/iSerial       "$1"
-      write $ANDROID_USB/functions     $USB_FUNCTIONS
-      write $ANDROID_USB/enable        1
-}
-# This lets us communicate errors to host (if it needs disable/enable then that's a problem)
-usb_info() {
-    # make sure USB is settled
-    echo "########################## usb_info: $1"
-    sleep 1
+    write $ANDROID_USB/enable        0
+    write $ANDROID_USB/functions     ""
+    write $ANDROID_USB/enable        1
+    usleep 500000 # 0.5 delay to attempt to remove rndis function
+    write $ANDROID_USB/enable        0
+    write $ANDROID_USB/idVendor      18D1
+    write $ANDROID_USB/idProduct     D001
+    write $ANDROID_USB/iManufacturer "Mer Boat Loader"
+    write $ANDROID_USB/iProduct      "$CUSTOMPRODUCT"
     write $ANDROID_USB/iSerial       "$1"
+    write $ANDROID_USB/functions     $USB_FUNCTIONS
+    write $ANDROID_USB/enable        1
 }
 
 
 run_debug_session() {
+    breathe
     CUSTOMPRODUCT=$1
-    echo "########################## Debug session : $1"
-    usb_setup "Mer Debug setting up (DONE_SWITCH=$DONE_SWITCH)"
+    log "########################## Debug session : $1"
+    log "DONE_SWITCH=$DONE_SWITCH"
 
     USB_IFACE=notfound
     /sbin/ifconfig rndis0 $LOCAL_IP && USB_IFACE=rndis0
@@ -226,10 +278,10 @@ run_debug_session() {
 
     # Unable to set up USB interface? Reboot.
     if [ x$USB_IFACE = xnotfound ]; then
-	    usb_info "Mer Debug: ERROR: could not setup USB as usb0 or rndis0"
-	    dmesg
-	    sleep 60 # plenty long enough to check usb on host
-	    reboot -f
+        log "Mer Debug: ERROR: could not setup USB as usb0 or rndis0"
+        dmesg
+        sleep 60 # plenty long enough to check usb on host
+        reboot -f
     fi
 
     # Create /etc/udhcpd.conf file.
@@ -240,22 +292,22 @@ run_debug_session() {
     echo "option subnet 255.255.255.0" >> /etc/udhcpd.conf
 
     # Be explicit about busybox so this works in a rootfs too
-    echo "########################## starting dhcpd"
+    log "########################## starting dhcpd"
     $EXPLICIT_BUSYBOX udhcpd
 
     HALT_BOOT="${2:-y}"
     set_welcome_msg $HALT_BOOT
 
     if [ -z $DISABLE_TELNET ]; then
-    # Non-blocking telnetd
-    echo "########################## starting telnetd"
-    # We run telnetd on different ports pre/post-switch_root This
-    # avoids problems with an unterminated pre-switch_root telnetd
-    # hogging the port
-    $EXPLICIT_BUSYBOX telnetd -b ${LOCAL_IP}:${TELNET_DEBUG_PORT} -l /bin/sh
+        # Non-blocking telnetd
+        log "########################## starting telnetd"
+        # We run telnetd on different ports pre/post-switch_root This
+        # avoids problems with an unterminated pre-switch_root telnetd
+        # hogging the port
+        $EXPLICIT_BUSYBOX telnetd -b ${LOCAL_IP}:${TELNET_DEBUG_PORT} -l /bin/sh
 
-    # For some reason this does not work in rootfs
-    usb_info "Mer Debug telnet on port $TELNET_DEBUG_PORT on $USB_IFACE $LOCAL_IP - also running udhcpd"
+        # For some reason this does not work in rootfs
+        log "Mer Debug telnet on port $TELNET_DEBUG_PORT on $USB_IFACE $LOCAL_IP - also running udhcpd"
     fi
 
     if [ "$HALT_BOOT" = "y" ]; then
@@ -271,25 +323,32 @@ run_debug_session() {
     fi
 }
 
+
 # writes to /diagnosis.log if there's a problem
 check_kernel_config() {
-    echo "Checking kernel config"
+    log "Checking kernel config"
     if [ ! -e /proc/config.gz ]; then
-	echo "No /proc/config.gz. Enable CONFIG_IKCONFIG and CONFIG_IKCONFIG_PROC" >> /diagnosis.log
+        log "No /proc/config.gz. Enable CONFIG_IKCONFIG and CONFIG_IKCONFIG_PROC" | tee -a /diagnosis.log
     else
-	# Must be =y
-	for x in CONFIG_CGROUPS CONFIG_AUTOFS4_FS CONFIG_DEVTMPFS_MOUNT CONFIG_DEVTMPFS CONFIG_UNIX CONFIG_INOTIFY_USER CONFIG_SYSVIPC CONFIG_NET CONFIG_PROC_FS CONFIG_SIGNALFD CONFIG_SYSFS CONFIG_TMPFS_POSIX_ACL CONFIG_VT; do
-		zcat /proc/config.gz | grep -E "^$x=y\$" || echo "$x=y not found in /proc/config.gz" >> /diagnosis.log
- 	done
-	# Must not be =y
-	for x in CONFIG_ANDROID_LOW_MEMORY_KILLER CONFIG_DUMMY CONFIG_SYSFS_DEPRECATED; do
-		zcat /proc/config.gz | grep -E "^$x=y\$" && echo "$x=y found in /proc/config.gz, must be disabled" >> /diagnosis.log
-	done
+        # Must be =y
+        for x in CONFIG_CGROUPS CONFIG_AUTOFS4_FS CONFIG_DEVTMPFS_MOUNT CONFIG_DEVTMPFS CONFIG_UNIX CONFIG_INOTIFY_USER CONFIG_SYSVIPC CONFIG_NET CONFIG_PROC_FS CONFIG_SIGNALFD CONFIG_SYSFS CONFIG_TMPFS_POSIX_ACL CONFIG_VT; do
+            zcat /proc/config.gz | grep -E "^$x=y\$" || echo "$x=y not found in /proc/config.gz" >> /diagnosis.log
+        done
+        # Must not be =y
+        for x in CONFIG_ANDROID_LOW_MEMORY_KILLER CONFIG_DUMMY CONFIG_SYSFS_DEPRECATED; do
+            zcat /proc/config.gz | grep -E "^$x=y\$" && echo "$x=y found in /proc/config.gz, must be disabled" >> /diagnosis.log
+        done
     fi
 }
 
-# Now either initrd or rootfs sequence
 
+
+
+
+
+
+#############################################################
+# Now either initrd or rootfs sequence
 if [ "$DONE_SWITCH" = "no" ]; then
     EXPLICIT_BUSYBOX=""
     TELNET_DEBUG_PORT=23
@@ -297,6 +356,7 @@ if [ "$DONE_SWITCH" = "no" ]; then
     date
 
     do_mount_devprocsys
+    breathe
 
     do_hotplug_scan
 
@@ -307,6 +367,8 @@ if [ "$DONE_SWITCH" = "no" ]; then
     check_kernel_config
 
     bootsplash
+
+    usb_setup "hybris-boot init-script (initrd)"
 
     mount_stowaways
 
@@ -319,34 +381,43 @@ if [ "$DONE_SWITCH" = "no" ]; then
     [ -f /target/init_enter_debug ] && DBG_REASON="/init_enter_debug exists"
     [ -f /target/init_disable_telnet ] && DISABLE_TELNET="y"
 
+    COUNT_VOLUP=$( dmesg | grep "Pressed KEY_VOLUMEUP" | wc -l )
+    [ "$COUNT_VOLUP" -ge 3 ] && DBG_REASON="Repeated VOLUMEUP"
+
+    log "DBG_REASON=$DBG_REASON"
     if ! [ "$DBG_REASON" = "" ] ; then
-	# During debug we export mmc too (some variations in location here)
-	lun=/sys/class/android_usb/f_mass_storage/lun/file
-	if [ -f $lun ]; then echo /dev/mmcblk0 > $lun; fi
-	lun=/sys/class/android_usb/f_mass_storage/lun0/file
-	if [ -f $lun ]; then echo /dev/mmcblk0 > $lun; fi
-	USB_FUNCTIONS=rndis,mass_storage
+        # During debug we export mmc too (some variations in location here)
+        lun=/sys/class/android_usb/f_mass_storage/lun/file
+        if [ -f $lun ]; then echo /dev/mmcblk0 > $lun; fi
 
-	run_debug_session "$DBG_REASON" "y"
+        lun=/sys/class/android_usb/f_mass_storage/lun0/file
+        if [ -f $lun ]; then echo /dev/mmcblk0 > $lun; fi
 
-	# Tidy up before we switch_root (rootfs init-debug leaves these running during bootup)
-	killall telnetd
-	killall udhcpd
+        USB_FUNCTIONS=rndis,mass_storage
+        run_debug_session "$DBG_REASON" "y"
 
-	USB_FUNCTIONS=rndis
-	usb_setup "Mer Debug: done debug, disabling storage"
+        # Tidy up before we switch_root (rootfs init-debug leaves these running during bootup)
+        killall telnetd
+        killall udhcpd
+
+        USB_FUNCTIONS=rndis
+        log "Mer Debug: done debug, disabling storage"
     fi
 
     # Disable mdev hotplug now - let udev handle it in main boot
     echo "" > /proc/sys/kernel/hotplug
 
     if [ -f "/target/init-debug" ]; then
+        log "exec switch_root /target /init-debug"
         exec switch_root /target /init-debug &> /target/init-debug-stderrout
     else
         # Prefer /sbin/preinit over /sbin/init
         [ -x /target/sbin/preinit ] && INIT=/sbin/preinit || INIT=/sbin/init
+        log "exec switch_root /target $INIT"
         exec switch_root /target $INIT &> /target/init-stderrout
     fi
+    blink 7
+    log "after exec switch_root"
     run_debug_session "Failed to boot init in real rootfs"
 
 else
@@ -355,6 +426,7 @@ else
     TELNET_DEBUG_PORT=2323
 
     do_mount_devprocsys
+    usb_setup "hybris-boot init-script (rootfs)"
 
     HALT_BOOT="n"
     [ -f /init_enter_debug2 ] && HALT_BOOT="y"
@@ -367,6 +439,9 @@ else
     # Now try to boot the real init
     # Prefer /sbin/preinit over /sbin/init
     [ -x /sbin/preinit ] && INIT=/sbin/preinit || INIT=/sbin/init
+    log "exec $INIT"
     exec $INIT &> /boot/systemd_stdouterr
     run_debug_session "init in real rootfs failed"
 fi
+log "end"
+

--- a/init-script
+++ b/init-script
@@ -183,8 +183,8 @@ mount_stowaways() {
         mount $DATA_PARTITION /data
         retval=$?
         if [ $retval -ne 0 ] ; then
-            blink 5
             log "Failed to mount /data [$retval]" >> /diagnosis.log
+            blink 5
             DEBUG_REASON="/data not mounted"
             return
         fi
@@ -193,8 +193,8 @@ mount_stowaways() {
         mount /data/rootfs.img /target
         retval=$?
         if [ $retval -ne 0 ] ; then
-            blink 6
             log "Failed to mount /target [$retval]" >> /diagnosis.log
+            blink 6
             DEBUG_REASON="/target not mounted"
             return
         fi
@@ -408,8 +408,8 @@ if [ "$DONE_SWITCH" = "no" ]; then
         log "exec switch_root /target $INIT" | tee -a /target/data/init-stderrout
         exec switch_root /target $INIT >> /target/data/init-stderrout 2>&1
     fi
-    blink 7
     log "after exec switch_root"
+    blink 7
     run_debug_session "Failed to boot init in real rootfs"
 
 else


### PR DESCRIPTION
Hi there!

This is more a request for comment rather than an actual pull request. Depending on your feedback I'd happily break certain features out into actual pull requests. 

This branch contains a number of improvements to the init-script. The following three changes I do actually suggest to merge into hybris-boot. I think they would greatly help porters and when cooperating and checking other porters log files. I have tested them on my own port for Nexus 7 deb.

- log to /dev/kmsg
- log if mounting fails
- enter telnet if mounting fails

There are also a few further changes below. They only work with a number of sleep's inside. Consequently, I think these changes are unsuitable for hybris-boot. However, they could be considered for hybris-recovery, e.g. log to usb iSerial. Others might even be too device specific - not sure.

- log to usb iSerial
- "breathe" the led when init is entered
- enter telnet if VOLUME UP is pressed during init
- blink the led in case of errors

Sorry to lump it all together, but I wanted to first test the waters, are you interested at all? As I said I'll happily make smaller PRs for interesting features. Looking forward to your comments