### PR TITLE
fixup-mountpoints: Add klte (Samsung Galaxy S5)

### DIFF
--- a/fixup-mountpoints
+++ b/fixup-mountpoints
@@ -1398,6 +1398,17 @@ case "$DEVICE" in
             "$@"
         ;;
 
+    "klte")
+        sed -i \
+            -e 's block/platform/msm_sdcc.1/by-name/system mmcblk0p23 ' \
+            -e 's block/platform/msm_sdcc.1/by-name/userdata mmcblk0p26 ' \
+            -e 's block/platform/msm_sdcc.1/by-name/cache mmcblk0p24 ' \
+            -e 's block/platform/msm_sdcc.1/by-name/apnhlos mmcblk0p1 ' \
+            -e 's block/platform/msm_sdcc.1/by-name/modem mmcblk0p2 ' \
+            -e 's block/platform/msm_sdcc.1/by-name/efs mmcblk0p12 ' \
+            "$@"
+        ;;
+
     "athene")
         sed -i \
             -e 's block/bootdevice/by-name/system mmcblk0p47 ' \


### PR DESCRIPTION
Link to original fstab.qcom: https://github.com/LineageOS/android_device_samsung_klte-common/blob/lineage-15.1/rootdir/etc/fstab.qcom

Output from adb shell:
```
~ # readlink -f /dev/block/platform/msm_sdcc.1/by-name/system
/dev/block/mmcblk0p23
~ # readlink -f /dev/block/platform/msm_sdcc.1/by-name/userdata
/dev/block/mmcblk0p26
~ # readlink -f /dev/block/platform/msm_sdcc.1/by-name/cache
/dev/block/mmcblk0p24
~ # readlink -f /dev/block/platform/msm_sdcc.1/by-name/apnhlos
/dev/block/mmcblk0p1
~ # readlink -f /dev/block/platform/msm_sdcc.1/by-name/modem
/dev/block/mmcblk0p2
~ # readlink -f /dev/block/platform/msm_sdcc.1/by-name/efs
/dev/block/mmcblk0p12
```