### PR TITLE
fixup-mountpoints: Add Redmi Note 2 (hermes) and unify formatting

### DIFF
--- a/fixup-mountpoints
+++ b/fixup-mountpoints
@@ -15,15 +15,15 @@ echo "Fixing mount-points for device $DEVICE"
 
 case "$DEVICE" in
     "suzu" | "kugo" | "blanc")
-         sed -i \
-             -e 's block/bootdevice/by-name/cache mmcblk0p24 ' \
-             -e 's block/bootdevice/by-name/dsp mmcblk0p13 ' \
-             -e 's block/bootdevice/by-name/modem mmcblk0p3 ' \
-             -e 's block/bootdevice/by-name/oem mmcblk0p28 ' \
-             -e 's block/bootdevice/by-name/persist mmcblk0p25 ' \
-             -e 's block/bootdevice/by-name/system mmcblk0p52 ' \
-             -e 's block/bootdevice/by-name/userdata mmcblk0p51 ' \
-             "$@"
+        sed -i \
+            -e 's block/bootdevice/by-name/cache mmcblk0p24 ' \
+            -e 's block/bootdevice/by-name/dsp mmcblk0p13 ' \
+            -e 's block/bootdevice/by-name/modem mmcblk0p3 ' \
+            -e 's block/bootdevice/by-name/oem mmcblk0p28 ' \
+            -e 's block/bootdevice/by-name/persist mmcblk0p25 ' \
+            -e 's block/bootdevice/by-name/system mmcblk0p52 ' \
+            -e 's block/bootdevice/by-name/userdata mmcblk0p51 ' \
+            "$@"
         ;;
 
     "serranodsdd")
@@ -455,10 +455,10 @@ case "$DEVICE" in
     "satsuma" | "smultron" | "urushi" | "zeus" | "jenad")
     # Untested for other revisions of Samsung GT-S6500:
     # | "jena" | "trebon")
-	sed -i \
-	    -e 's /block/ / ' \
-	    "$@"
-	;;
+        sed -i \
+            -e 's /block/ / ' \
+            "$@"
+        ;;
 
     "shieldtablet")
         sed -i \
@@ -504,6 +504,7 @@ case "$DEVICE" in
             -e 's block/platform/msm_sdcc.1/by-name/userdata mmcblk0p28 ' \
             "$@"
         ;;
+
     "ace")
        sed -i \
             -e 's block/platform/msm_sdcc.2/by-num/p25 mmcblk0p25 ' \
@@ -512,6 +513,7 @@ case "$DEVICE" in
             -e 's block/platform/msm_sdcc.2/by-num/p28 mmcblk0p28 ' \
             "$@"
         ;;
+
     "flo"|"deb")
         sed -i \
             -e 's block/platform/msm_sdcc.1/by-name/persist mmcblk0p4 ' \
@@ -524,6 +526,7 @@ case "$DEVICE" in
             -e 's block/platform/msm_sdcc.1/by-name/misc mmcblk0p24 ' \
             "$@"
         ;;
+
     "yuga" | "odin" | "dogo" | "pollux" | "pollux_windy")
         sed -i \
             -e 's block/platform/msm_sdcc.1/by-name/boot mmcblk0p17 ' \
@@ -533,6 +536,7 @@ case "$DEVICE" in
             -e 's block/platform/msm_sdcc.1/by-name/LTALabel mmcblk1 ' \
             "$@"
         ;;
+
     "z3c" | "sirius" | "z3" | "leo")
     # Z3 compact is also called "aries" | "d5803" in aosp (called z3c in cm12.1)
     # Z2 is also called "d6503" in aosp (called sirius in cm12.1)
@@ -565,8 +569,9 @@ case "$DEVICE" in
              -e 's block/platform/msm_sdcc.1/by-name/userdata mmcblk0p25 ' \
             "$@"
          ;;
+
     "kis3")
-       sed -i \
+        sed -i \
             -e 's block/platform/msm_sdcc.1/by-name/system mmcblk0p12 ' \
             -e 's block/platform/msm_sdcc.1/by-name/userdata mmcblk0p13 ' \
             -e 's block/platform/msm_sdcc.1/by-name/cache mmcblk0p15 ' \
@@ -576,6 +581,7 @@ case "$DEVICE" in
             -e 's block/platform/msm_sdcc.1/by-name/persist mmcblk0p14 ' \
             "$@"
         ;;
+
     "m7spr")
         sed -i \
             -e 's block/platform/msm_sdcc.1/by-name/adsp mmcblk0p16 ' \
@@ -637,7 +643,7 @@ case "$DEVICE" in
         ;;
 
     "wt88047")
-       sed -i \
+        sed -i \
             -e 's block/bootdevice/by-name/userdata mmcblk0p30 ' \
             -e 's block/bootdevice/by-name/boot mmcblk0p22 ' \
             -e 's block/bootdevice/by-name/system mmcblk0p23 ' \
@@ -647,8 +653,9 @@ case "$DEVICE" in
             -e 's block/bootdevice/by-name/persist mmcblk0p25 ' \
             "$@"
         ;;
+
     "find5")
-       sed -i \
+        sed -i \
             -e 's block/platform/msm_sdcc.1/by-name/modem mmcblk0p1 ' \
             -e 's block/platform/msm_sdcc.1/by-name/persist mmcblk0p21 ' \
             -e 's block/platform/msm_sdcc.1/by-name/system mmcblk0p19 ' \
@@ -656,8 +663,9 @@ case "$DEVICE" in
             -e 's block/platform/msm_sdcc.1/by-name/userdata mmcblk0p20 ' \
             "$@"
         ;;
+
     "cancro")
-       sed -i \
+        sed -i \
             -e 's block/platform/msm_sdcc.1/by-name/DDR mmcblk0p4 ' \
             -e 's block/platform/msm_sdcc.1/by-name/aboot mmcblk0p7 ' \
             -e 's block/platform/msm_sdcc.1/by-name/bk1 mmcblk0p8 ' \
@@ -685,8 +693,9 @@ case "$DEVICE" in
             -e 's block/platform/msm_sdcc.1/by-name/userdata mmcblk0p25 ' \
             "$@"
         ;;
+
     "gemini")
-       sed -i \
+        sed -i \
             -e 's block/bootdevice/by-name/aboot sde23 ' \
             -e 's block/bootdevice/by-name/abootbak sde24 ' \
             -e 's block/bootdevice/by-name/apdp sde5 ' \
@@ -756,6 +765,7 @@ case "$DEVICE" in
             -e 's block/bootdevice/by-name/xblbak sdc1 ' \
             "$@"
         ;;
+
     "gts210ltexx"|"gts210wifi")
        sed -i \
             -e 's block/platform/15540000.dwmmc0/by-name/BOOT mmcblk0p9 ' \
@@ -765,6 +775,7 @@ case "$DEVICE" in
             -e 's block/platform/15540000.dwmmc0/by-name/USERDATA mmcblk0p22 ' \
             "$@"
         ;;
+
     "kenzo")
        sed -i \
             -e 's block/bootdevice/by-name/DDR mmcblk0p15 ' \
@@ -813,7 +824,7 @@ case "$DEVICE" in
             -e 's block/bootdevice/by-name/tz mmcblk0p8 ' \
             -e 's block/bootdevice/by-name/tzbak mmcblk0p9 ' \
             -e 's block/bootdevice/by-name/userdata mmcblk0p46 ' \
-	    "$@"
+            "$@"
         ;;
 
     "ido")
@@ -849,7 +860,7 @@ case "$DEVICE" in
             -e 's block/bootdevice/by-name/tz mmcblk0p8 ' \
             -e 's block/bootdevice/by-name/tzbak mmcblk0p9 ' \
             -e 's block/bootdevice/by-name/userdata mmcblk0p31 ' \
-           "$@"
+            "$@"
         ;;
 
     "armani")
@@ -954,7 +965,7 @@ case "$DEVICE" in
            "$@"
         ;;
 
-	"oneplus3")
+    "oneplus3")
         sed -i \
             -e 's block/bootdevice/by-name/LOGO sde17 ' \
             -e 's block/bootdevice/by-name/aboot sde15 ' \
@@ -1001,7 +1012,7 @@ case "$DEVICE" in
             -e 's block/bootdevice/by-name/recovery sde21 ' \
             -e 's block/bootdevice/by-name/reserve sdd1 ' \
             -e 's block/bootdevice/by-name/reserve1 sda12 ' \
-	    -e 's block/bootdevice/by-name/reserve2 sda13 ' \
+            -e 's block/bootdevice/by-name/reserve2 sda13 ' \
             -e 's block/bootdevice/by-name/rpm sde1 ' \
             -e 's block/bootdevice/by-name/rpmbak sde2 ' \
             -e 's block/bootdevice/by-name/sec sde8 ' \
@@ -1040,19 +1051,20 @@ case "$DEVICE" in
 
     "pme")
         sed -i \
-             -e 's block/platform/soc/7464900.sdhci/by-name/adsp mmcblk0p31 ' \
-             -e 's block/platform/soc/7464900.sdhci/by-name/cache mmcblk0p61 ' \
-             -e 's block/platform/soc/7464900.sdhci/by-name/carrier mmcblk0p53 ' \
-             -e 's block/platform/soc/7464900.sdhci/by-name/dsp mmcblk0p57 ' \
-             -e 's block/platform/soc/7464900.sdhci/by-name/persist mmcblk0p48 ' \
-             -e 's block/platform/soc/7464900.sdhci/by-name/radio mmcblk0p30 ' \
-             -e 's block/platform/soc/7464900.sdhci/by-name/slpi mmcblk0p33 ' \
-             -e 's block/platform/soc/7464900.sdhci/by-name/system mmcblk0p62 ' \
-             -e 's block/platform/soc/7464900.sdhci/by-name/userdata mmcblk0p63 ' \
-             -e 's block/platform/soc/7464900.sdhci/by-name/venus mmcblk0p36 ' \
+            -e 's block/platform/soc/7464900.sdhci/by-name/adsp mmcblk0p31 ' \
+            -e 's block/platform/soc/7464900.sdhci/by-name/cache mmcblk0p61 ' \
+            -e 's block/platform/soc/7464900.sdhci/by-name/carrier mmcblk0p53 ' \
+            -e 's block/platform/soc/7464900.sdhci/by-name/dsp mmcblk0p57 ' \
+            -e 's block/platform/soc/7464900.sdhci/by-name/persist mmcblk0p48 ' \
+            -e 's block/platform/soc/7464900.sdhci/by-name/radio mmcblk0p30 ' \
+            -e 's block/platform/soc/7464900.sdhci/by-name/slpi mmcblk0p33 ' \
+            -e 's block/platform/soc/7464900.sdhci/by-name/system mmcblk0p62 ' \
+            -e 's block/platform/soc/7464900.sdhci/by-name/userdata mmcblk0p63 ' \
+            -e 's block/platform/soc/7464900.sdhci/by-name/venus mmcblk0p36 ' \
             "$@"
         ;;
-	"Z00L"|"Z00LD"|"Z00W"|"Z00WD"|"Z00M"|"Z00MD"|"Z00MDD"|"Z00T"|"Z00TD"|"Z00U"|"Z00UD"|"Z00UDH"|"Z00UDB"|"Z011"|"Z011D"|"Z011DD")
+
+    "Z00L"|"Z00LD"|"Z00W"|"Z00WD"|"Z00M"|"Z00MD"|"Z00MDD"|"Z00T"|"Z00TD"|"Z00U"|"Z00UD"|"Z00UDH"|"Z00UDB"|"Z011"|"Z011D"|"Z011DD")
         sed -i \
             -e 's block/platform/soc.0/7824900.sdhci/by-name/asdf mmcblk0p33 ' \
             -e 's block/platform/soc.0/7824900.sdhci/by-name/boot mmcblk0p37 ' \
@@ -1065,7 +1077,8 @@ case "$DEVICE" in
             -e 's block/platform/soc.0/7824900.sdhci/by-name/system mmcblk0p45 ' \
             -e 's block/platform/soc.0/7824900.sdhci/by-name/userdata mmcblk0p46 ' \
             "$@"
-	;;
+        ;;
+
     "oneplus3")
         sed -i \
             -e 's block/bootdevice/by-name/boot sde18 ' \
@@ -1074,6 +1087,7 @@ case "$DEVICE" in
             -e 's block/bootdevice/by-name/cache sda3 ' \
             "$@"
         ;;
+
     "cheeseburger")
         sed -i \
             -e 's block/bootdevice/by-name/boot sde19 ' \
@@ -1085,6 +1099,7 @@ case "$DEVICE" in
             -e 's block/bootdevice/by-name/bluetooth sde24 ' \
             "$@"
         ;;
+
     "oneplus2")
         sed -i \
             -e 's block/bootdevice/by-name/boot mmcblk0p35 ' \
@@ -1096,6 +1111,7 @@ case "$DEVICE" in
             -e 's block/bootdevice/by-name/bluetooth mmcblk0p2 ' \
             "$@"
         ;;
+
     "shamu")
         sed -i \
             -e 's block/platform/msm_sdcc.1/by-name/boot mmcblk0p37 ' \
@@ -1105,6 +1121,7 @@ case "$DEVICE" in
             -e 's block/platform/msm_sdcc.1/by-name/modem mmcblk0p1 ' \
             "$@"
         ;;
+
     "flounder")
         sed -i \
             -e 's block/platform/sdhci-tegra.3/by-name/LNX mmcblk0p16 ' \
@@ -1114,6 +1131,7 @@ case "$DEVICE" in
             -e 's block/platform/sdhci-tegra.3/by-name/VNR mmcblk0p24 ' \
             "$@"
         ;;
+
     "tulip-chiphd")
         sed -i \
             -e 's block/mmcblk0p1 mmcblk0p1 ' \
@@ -1219,6 +1237,7 @@ case "$DEVICE" in
             -e 's block/bootdevice/by-name/userdata mmcblk0p42 ' \
             "$@"
         ;;
+
     "sumire")
         sed -i \
             -e 's block/platform/soc.0/by-name/DDR mmcblk0p7 ' \
@@ -1266,6 +1285,7 @@ case "$DEVICE" in
             -e 's block/platform/soc.0/by-name/userdata mmcblk0p42 ' \
             "$@"
         ;;
+
     "peregrine")
         sed -i \
             -e 's block/bootdevice/by-name/system mmcblk0p34 ' \
@@ -1279,6 +1299,7 @@ case "$DEVICE" in
             -e 's block/bootdevice/by-name/misc mmcblk0p30 ' \
             "$@"
         ;;
+
     "harpia")
         sed -i \
             -e 's block/bootdevice/by-name/system mmcblk0p39 ' \
@@ -1292,6 +1313,7 @@ case "$DEVICE" in
             -e 's block/bootdevice/by-name/misc mmcblk0p9 ' \
             "$@"
         ;;
+
     "surnia")
         sed -i \
             -e 's block/platform/soc.0/by-name/DDR mmcblk0p3 ' \
@@ -1340,6 +1362,7 @@ case "$DEVICE" in
             -e 's block/platform/soc.0/by-name/utagsBackup mmcblk0p17 ' \
             "$@"
         ;;
+
     "merlin")
         sed -i \
             -e 's block/bootdevice/by-name/system mmcblk0p41 ' \
@@ -1353,6 +1376,7 @@ case "$DEVICE" in
             -e 's block/bootdevice/by-name/misc mmcblk0p9 ' \
             "$@"
         ;;
+
     "natrium")
         sed -i \
             -e 's block/bootdevice/by-name/boot sde36 ' \
@@ -1422,7 +1446,7 @@ case "$DEVICE" in
             -e 's block/platform/sdhci-tegra.3/by-name/DLG mmcblk0p19 ' \
             -e 's block/platform/sdhci-tegra.3/by-name/ISD mmcblk0p14 ' \
             -e 's block/platform/sdhci-tegra.3/by-name/UDA mmcblk0p15 ' \
-	   "$@"
+            "$@"
         ;;
 
     "scorpion" | "scorpion_windy")
@@ -1497,7 +1521,7 @@ case "$DEVICE" in
             -e 's block/bootdevice/by-name/misc mmcblk0p31 ' \
             "$@"
         ;;
-	
+
     "jfltetmo")
        sed -i \
             -e 's block/platform/msm_sdcc.1/by-name/aboot mmcblk0p6 ' \
@@ -1573,27 +1597,27 @@ case "$DEVICE" in
 
     "trunk")
         sed -i \
-	    -e 's block/bootdevice/by-name/boot mmcblk0p20 ' \
-	    -e 's block/bootdevice/by-name/cache mmcblk0p24 ' \
-	    -e 's block/bootdevice/by-name/misc mmcblk0p26 ' \
-	    -e 's block/bootdevice/by-name/modem mmcblk0p01 ' \
-	    -e 's block/bootdevice/by-name/persist mmcblk0p25 ' \
-	    -e 's block/bootdevice/by-name/system mmcblk0p23 ' \
-	    -e 's block/bootdevice/by-name/userdata mmcblk0p30 ' \
-	    -e 's block/bootdevice/by-name/config mmcblk0p28 ' \
-	    "$@"
-	;;
+            -e 's block/bootdevice/by-name/boot mmcblk0p20 ' \
+            -e 's block/bootdevice/by-name/cache mmcblk0p24 ' \
+            -e 's block/bootdevice/by-name/misc mmcblk0p26 ' \
+            -e 's block/bootdevice/by-name/modem mmcblk0p01 ' \
+            -e 's block/bootdevice/by-name/persist mmcblk0p25 ' \
+            -e 's block/bootdevice/by-name/system mmcblk0p23 ' \
+            -e 's block/bootdevice/by-name/userdata mmcblk0p30 ' \
+            -e 's block/bootdevice/by-name/config mmcblk0p28 ' \
+            "$@"
+        ;;
 
     "land" | "rolex" | "riva")
         sed -i \
-	    -e 's block/bootdevice/by-name/system mmcblk0p24 ' \
-	    -e 's block/bootdevice/by-name/userdata mmcblk0p49 ' \
-	    -e 's block/bootdevice/by-name/cache mmcblk0p25 ' \
-	    -e 's block/bootdevice/by-name/persist mmcblk0p26 ' \
-	    -e 's block/bootdevice/by-name/dsp mmcblk0p12 ' \
-	    -e 's block/bootdevice/by-name/modem mmcblk0p1 ' \
-	    "$@"
-	;;
+            -e 's block/bootdevice/by-name/system mmcblk0p24 ' \
+            -e 's block/bootdevice/by-name/userdata mmcblk0p49 ' \
+            -e 's block/bootdevice/by-name/cache mmcblk0p25 ' \
+            -e 's block/bootdevice/by-name/persist mmcblk0p26 ' \
+            -e 's block/bootdevice/by-name/dsp mmcblk0p12 ' \
+            -e 's block/bootdevice/by-name/modem mmcblk0p1 ' \
+            "$@"
+        ;;
 
     "hermes")
         sed -i \
@@ -1619,7 +1643,7 @@ case "$DEVICE" in
         ;;
 
     *)
-	cat <<EOF
+        cat <<EOF
 
 ****************************************************************
 ****************************************************************

--- a/fixup-mountpoints
+++ b/fixup-mountpoints
@@ -1562,7 +1562,7 @@ case "$DEVICE" in
             -e 's block/bootdevice/by-name/modem sde12 ' \
             "$@"
         ;;
-	
+
     "nicki")
         sed -i \
             -e 's block/platform/msm_sdcc.1/by-name/cache mmcblk0p26 ' \
@@ -1594,6 +1594,29 @@ case "$DEVICE" in
 	    -e 's block/bootdevice/by-name/modem mmcblk0p1 ' \
 	    "$@"
 	;;
+
+    "hermes")
+        sed -i \
+            -e 's block/platform/mtk-msdc.0/11230000.MSDC0/by-name/boot mmcblk0p7 ' \
+            -e 's block/platform/mtk-msdc.0/11230000.MSDC0/by-name/cache mmcblk0p16 ' \
+            -e 's block/platform/mtk-msdc.0/11230000.MSDC0/by-name/expdb mmcblk0p12 ' \
+            -e 's block/platform/mtk-msdc.0/11230000.MSDC0/by-name/flashinfo mmcblk0p18 ' \
+            -e 's block/platform/mtk-msdc.0/11230000.MSDC0/by-name/lk mmcblk0p6 ' \
+            -e 's block/platform/mtk-msdc.0/11230000.MSDC0/by-name/logo mmcblk0p11 ' \
+            -e 's block/platform/mtk-msdc.0/11230000.MSDC0/by-name/nvram mmcblk0p2 ' \
+            -e 's block/platform/mtk-msdc.0/11230000.MSDC0/by-name/para mmcblk0p10 ' \
+            -e 's block/platform/mtk-msdc.0/11230000.MSDC0/by-name/proinfo mmcblk0p1 ' \
+            -e 's block/platform/mtk-msdc.0/11230000.MSDC0/by-name/protect1 mmcblk0p3 ' \
+            -e 's block/platform/mtk-msdc.0/11230000.MSDC0/by-name/protect2 mmcblk0p4 ' \
+            -e 's block/platform/mtk-msdc.0/11230000.MSDC0/by-name/recovery mmcblk0p8 ' \
+            -e 's block/platform/mtk-msdc.0/11230000.MSDC0/by-name/seccfg mmcblk0p5 ' \
+            -e 's block/platform/mtk-msdc.0/11230000.MSDC0/by-name/secro mmcblk0p9 ' \
+            -e 's block/platform/mtk-msdc.0/11230000.MSDC0/by-name/system mmcblk0p15 ' \
+            -e 's block/platform/mtk-msdc.0/11230000.MSDC0/by-name/tee1 mmcblk0p13 ' \
+            -e 's block/platform/mtk-msdc.0/11230000.MSDC0/by-name/tee2 mmcblk0p14 ' \
+            -e 's block/platform/mtk-msdc.0/11230000.MSDC0/by-name/userdata mmcblk0p17 ' \
+            "$@"
+        ;;
 
     *)
 	cat <<EOF


### PR DESCRIPTION
This changeset adds support for Redmi Note 2 (hermes) and attempts to unity formatting in that file (spaces used for indentation, empty line between different devices, same indentation levels).