### PR TITLE
fixup-mountpoints: Add honami&amami compatibles

### DIFF
--- a/fixup-mountpoints
+++ b/fixup-mountpoints
@@ -609,7 +609,7 @@ case "$DEVICE" in
             "$@"
         ;;
 
-    "z3c" | "sirius" | "z3" | "leo")
+    "z3c" | "sirius" | "z3" | "leo" | "honami" | "amami")
     # Z3 compact is also called "aries" | "d5803" in aosp (called z3c in cm12.1)
     # Z2 is also called "d6503" in aosp (called sirius in cm12.1)
     # untested for "amami" | "tianchi")


### PR DESCRIPTION
Amami is actually untested, but all of these devices SHOULD have an identical partition layout, due to being based on the same (well if we consider 8974 and 8974pro same, which they almost are) SoC.